### PR TITLE
feature: [step 1] 포인트 기본 기능 정책추가(잔고 부족시 예외발생), 동시성 제어 및 테스트

### DIFF
--- a/src/test/java/io/hhplus/tdd/PointConcurrencyTest.java
+++ b/src/test/java/io/hhplus/tdd/PointConcurrencyTest.java
@@ -1,0 +1,73 @@
+package io.hhplus.tdd;
+
+import io.hhplus.tdd.point.UserPoint;
+import io.hhplus.tdd.point.service.PointService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+
+@SpringBootTest
+public class PointConcurrencyTest {
+
+    @Autowired
+    private PointService pointService;
+
+
+    @Test
+    void charge_동시성_테스트_CompletableFuture() throws InterruptedException, ExecutionException {
+
+        int threadCount = 200;
+        int point = 100;
+
+        // CompletableFuture 리스트 생성
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+
+        for (int i = 0; i < threadCount; i++) {
+            CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
+                pointService.charge(1L, point);
+            });
+            futures.add(future);
+        }
+
+        // 모든 CompletableFuture가 완료될 때까지 기다림
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get();
+
+        // then
+        UserPoint userPoint = pointService.selectById(1L);
+        Assertions.assertEquals(threadCount * point, userPoint.point());
+    }
+
+
+    @Test
+    void use_동시성_테스트_CompletableFuture() throws InterruptedException, ExecutionException {
+        int threadCount = 100;
+        long initialPoint = 10000; // 초기 포인트
+        long usePoint = 100; // 차감할 포인트
+
+        // 초기 포인트를 설정
+        pointService.charge(1L, initialPoint);
+
+        // CompletableFuture 리스트 생성
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+
+        for (int i = 0; i < threadCount; i++) {
+            CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
+                pointService.use(1L, usePoint);
+            });
+            futures.add(future);
+        }
+
+        // 모든 CompletableFuture가 완료될 때까지 기다림
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get();
+
+        // then
+        UserPoint userPoint = pointService.selectById(1L);
+        long expectedPoint = initialPoint - (threadCount * usePoint); // 예상 포인트 계산
+        Assertions.assertEquals(expectedPoint, userPoint.point());
+    }
+}


### PR DESCRIPTION
Pull Request: 포인트 충전 및 사용 정책 추가 및 동시성 제어 리팩토링

변경 사항

	•	포인트 충전 및 사용에 대한 정책을 추가했습니다:
	•	잔고 부족: 사용자가 요청한 포인트 사용 시 잔고가 부족할 경우 예외 처리.
	•	동시성 제어 리팩토링:
	        여러 요청이 동시에 들어오더라도, 요청들이 순서대로 처리되도록 로직을 리팩토링했습니다.
	•	동시성 제어 통합 테스트:
	        동시성 제어 기능에 대한 통합 테스트를 작성하였습니다.

검토 요청

	•	새로운 정책 구현에는 시간을 많이 할애하지 못해서 내용이 부족합니다. 추가로 구현하면 좋을 정책에 대한 조언 있으시면 피드백 주시면 감사하겠습니다.

	